### PR TITLE
Set PType to avoid an open "p"

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -21,6 +21,13 @@ class syntax_plugin_inlinetoc extends DokuWiki_Syntax_Plugin {
     }
 
     /**
+     * What kind of type are we?
+     */
+	function getPType() {
+		return 'block';
+	}
+
+    /**
      * Where to sort in? (took the same as for ~~NOTOC~~)
      */
     function getSort() {


### PR DESCRIPTION
Otherwise there will be a "p" directly before the inlinetoc2-div (which will be closed after the div). This kind of HTML is not valid.
